### PR TITLE
Fixes the helpers on Rails 5

### DIFF
--- a/lib/tabs_on_rails/action_controller.rb
+++ b/lib/tabs_on_rails/action_controller.rb
@@ -14,8 +14,8 @@ module TabsOnRails
 
     included do
       extend        ClassMethods
-      helper        HelperMethods
-      helper_method :current_tab, :current_tab?
+      ::ActionController::Base.helper        HelperMethods
+      ::ActionController::Base.helper_method :current_tab, :current_tab?
     end
 
     


### PR DESCRIPTION
On Rails 5 loading tabs_on_rails fails:

Same fix as in weppos/breadcrumbs_on_rails#77…

```
Code/rails-5-project (master *) » ./bin/rails server
=> Booting Puma
=> Rails 5.0.0.rc1 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
Exiting
~/.rvm/gems/ruby-2.3.1/gems/tabs_on_rails-2.2.0/lib/tabs_on_rails/action_controller.rb:17:in `block in <module:ActionController>': undefined method `helper' for ActionController::API:Class (NoMethodError)
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/concern.rb:120:in `class_eval'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/concern.rb:120:in `append_features'
    from ~/.rvm/gems/ruby-2.3.1/gems/tabs_on_rails-2.2.0/lib/tabs_on_rails/railtie.rb:20:in `include'
    from ~/.rvm/gems/ruby-2.3.1/gems/tabs_on_rails-2.2.0/lib/tabs_on_rails/railtie.rb:20:in `block in <top (required)>'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:38:in `instance_eval'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:38:in `execute_hook'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:44:in `each'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
    from ~/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0.rc1/lib/action_controller/api.rb:145:in `<class:API>'
    from ~/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0.rc1/lib/action_controller/api.rb:88:in `<module:ActionController>'
    from ~/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0.rc1/lib/action_controller/api.rb:5:in `<top (required)>'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/dependencies.rb:293:in `require'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/dependencies.rb:293:in `block in require'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/dependencies.rb:259:in `load_dependency'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/dependencies.rb:293:in `require'
    from ~/.rvm/gems/ruby-2.3.1/gems/bugsnag-4.1.0/lib/bugsnag/railtie.rb:47:in `block in <class:Railtie>'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:44:in `each'
    from ~/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.rc1/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/application/bootstrap.rb:78:in `block in <module:Bootstrap>'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/initializable.rb:30:in `instance_exec'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/initializable.rb:30:in `run'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/initializable.rb:55:in `block in run_initializers'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `call'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/initializable.rb:54:in `run_initializers'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/application.rb:352:in `initialize!'
    from ~/Code/rails-5-project/config/environment.rb:5:in `<top (required)>'
    from ~/Code/rails-5-project/config.ru:3:in `require_relative'
    from ~/Code/rails-5-project/config.ru:3:in `block in <main>'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/builder.rb:55:in `instance_eval'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/builder.rb:55:in `initialize'
    from ~/Code/rails-5-project/config.ru:in `new'
    from ~/Code/rails-5-project/config.ru:in `<main>'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/builder.rb:49:in `eval'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/builder.rb:49:in `new_from_string'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/builder.rb:40:in `parse_file'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/server.rb:318:in `build_app_and_options_from_config'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/server.rb:218:in `app'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/server.rb:59:in `app'
    from ~/.rvm/gems/ruby-2.3.1/gems/rack-2.0.0.rc1/lib/rack/server.rb:353:in `wrapped_app'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/server.rb:124:in `log_to_stdout'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/server.rb:77:in `start'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/commands_tasks.rb:90:in `block in server'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/commands_tasks.rb:85:in `tap'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/commands_tasks.rb:85:in `server'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
    from ~/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0.rc1/lib/rails/commands.rb:18:in `<top (required)>'
    from ~/Code/rails-5-project/bin/rails:9:in `require'
    from ~/Code/rails-5-project/bin/rails:9:in `<top (required)>'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/client/rails.rb:28:in `load'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/client/rails.rb:28:in `call'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/client/command.rb:7:in `call'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/client.rb:30:in `run'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/bin/spring:49:in `<top (required)>'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/binstub.rb:11:in `load'
    from ~/.rvm/gems/ruby-2.3.1/gems/spring-1.7.1/lib/spring/binstub.rb:11:in `<top (required)>'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ~/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ~/Code/rails-5-project/bin/spring:13:in `<top (required)>'
    from bin/rails:3:in `load'
    from bin/rails:3:in `<main>'
```
